### PR TITLE
Replace potentially offensive `blacklist` with `denylist`

### DIFF
--- a/Commands/AI.cs
+++ b/Commands/AI.cs
@@ -32,9 +32,9 @@ public class AI
 
         if(!ctx.Channel.IsPrivate)
         {
-            if(!Filter.IsSafe((string)cmdargs[0]) && Globals.cfg.useblacklist)
+            if(!Filter.IsSafe((string)cmdargs[0]) && Globals.cfg.usedenylist)
             {
-                await ctx.Message.RespondAsync($"Your request was blocked for using blacklisted words!");
+                await ctx.Message.RespondAsync($"Your request was blocked for using denylisted words!");
                 return;
             }
         }

--- a/Config/Config.cs
+++ b/Config/Config.cs
@@ -1,3 +1,3 @@
 namespace Ellie;
 
-public record Config(string token, List<string> blacklist, bool useblacklist, string defaultmodel, List<ulong> adminids);
+public record Config(string token, List<string> denylist, bool usedenylist, string defaultmodel, List<ulong> adminids);

--- a/Filter.cs
+++ b/Filter.cs
@@ -10,7 +10,7 @@ public static class Filter
         {
             foreach(string str in section.Split(' '))
             {
-                foreach(string word in Globals.cfg.blacklist)
+                foreach(string word in Globals.cfg.denylist)
                 {
                     if(str == word)
                     {

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ config.json must include this text:
 ```json
 {
     "token": "Your Discord Bot Token",
-    "blacklist": [ "Put Blacklisted Keywords Here" ],
-    "useblacklist": true,
+    "denylist": [ "Put Denylisted Keywords Here" ],
+    "usedenylist": true,
     "defaultmodel": "Name Of The Model You Want To Be Loaded By Default",
     "adminids": []
 }


### PR DESCRIPTION
In this pull request, I have performed a global search and replace operation to change all instances of blacklist to denylist throughout the codebase.

# Why This Change is Necessary

The use of the term blacklist may be offensive and alienating to some individuals, as it has racial connotations. By making this change to denylist, we demonstrate our commitment to fostering a welcoming and inclusive environment for all contributors and users of this software.